### PR TITLE
[RFC] Case-insensitive attribute setter

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -56,19 +56,24 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
      * @return the first matching attribute value if set; or empty string if not set.
      */
     public String getIgnoreCase(String key) {
+        Attribute attr = getAttributeIgnoreCase(key);
+        return attr != null ? attr.getValue() : "";
+    }
+
+    private Attribute getAttributeIgnoreCase(String key) {
         Validate.notEmpty(key);
         if (attributes == null)
-            return "";
+            return null;
 
         Attribute attr = attributes.get(key);
         if (attr != null)
-            return attr.getValue();
+            return attr;
 
         for (String attrKey : attributes.keySet()) {
             if (attrKey.equalsIgnoreCase(key))
-                return attributes.get(attrKey).getValue();
+                return attributes.get(attrKey);
         }
-        return "";
+        return null;
     }
 
     /**
@@ -79,6 +84,15 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
     public void put(String key, String value) {
         Attribute attr = new Attribute(key, value);
         put(attr);
+    }
+
+    void putIgnoreCase(String key, String value) {
+        Attribute oldAttr = getAttributeIgnoreCase(key);
+        if (oldAttr != null && !oldAttr.getKey().equals(key)) {
+            attributes.remove(oldAttr.getKey());
+        }
+
+        put(key, value);
     }
 
     /**

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -92,13 +92,14 @@ public abstract class Node implements Cloneable {
     }
 
     /**
-     * Set an attribute (key=value). If the attribute already exists, it is replaced.
+     * Set an attribute (key=value). If the attribute already exists, it is replaced. The attribute key comparison is
+     * <b>case insensitive</b>.
      * @param attributeKey The attribute key.
      * @param attributeValue The attribute value.
      * @return this (for chaining)
      */
     public Node attr(String attributeKey, String attributeValue) {
-        attributes.put(attributeKey, attributeValue);
+        attributes.putIgnoreCase(attributeKey, attributeValue);
         return this;
     }
 

--- a/src/test/java/org/jsoup/nodes/NodeTest.java
+++ b/src/test/java/org/jsoup/nodes/NodeTest.java
@@ -289,4 +289,29 @@ public class NodeTest {
         assertTrue(el.text().equals("None"));
         assertTrue(elClone.text().equals("Text"));
     }
+
+    @Test public void changingAttributeValueShouldReplaceExistingAttributeCaseInsensitive() {
+        Document document = Jsoup.parse("<INPUT id=\"foo\" NAME=\"foo\" VALUE=\"\">");
+        Element inputElement = document.select("#foo").first();
+
+        inputElement.attr("value","bar");
+
+        assertEquals(singletonAttributes("value", "bar"), getAttributesCaseInsensitive(inputElement, "value"));
+    }
+
+    private Attributes getAttributesCaseInsensitive(Element element, String attributeName) {
+        Attributes matches = new Attributes();
+        for (Attribute attribute : element.attributes()) {
+            if (attribute.getKey().equalsIgnoreCase(attributeName)) {
+                matches.put(attribute);
+            }
+        }
+        return matches;
+    }
+
+    private Attributes singletonAttributes(String key, String value) {
+        Attributes attributes = new Attributes();
+        attributes.put(key, value);
+        return attributes;
+    }
 }


### PR DESCRIPTION
Problem (see https://github.com/jhy/jsoup/issues/815):

```java
Document document = Jsoup.parse("<INPUT id=\"foo\" NAME=\"foo\" VALUE=\"\">");
Element inputElement = document.select("#foo").first();

inputElement.attr("value","bar");

System.out.println(inputElement.outerHtml()); 
// Output: <input id="foo" NAME="foo" VALUE="" value="bar">
// Wanted: <input id="foo" NAME="foo" value="bar">
```

This changes `Node#attr(String, String)` to compare attribute keys case-insensitive to see if there is an existing attribute that needs to be replaced. The order of attributes is retained when the case of the new attribute key and the existing attribute key match. If not the existing attribute is removed and the new one is added at the end. This is mostly due to the limitations of `LinkedHashMap`.

I'm not convinced this is the best solution to the problem. It's probably not the intended behavior when working with a parser that retained the case of element names (and attributes?). On the other hand, `Node#attr(String)` always does case-insensitive comparisons, too. Maybe the API could use some refinement.